### PR TITLE
Connector appearance

### DIFF
--- a/autoloads/dome_connections.gd
+++ b/autoloads/dome_connections.gd
@@ -52,6 +52,7 @@ func draw_connections():
 		line.add_point(i.a.global_position)
 		line.add_point(i.b.global_position)
 		line.default_color = Color(1,1,1,0.2)
+		line.z_index=-1
 		line_nodes.append(line)
 	return line_nodes
 

--- a/autoloads/dome_connections.gd
+++ b/autoloads/dome_connections.gd
@@ -3,8 +3,6 @@ extends Node
 # connections represented as a "directed graph", i.e. each connection is directional
 var connections = []
 # visual representation of each connection
-# https://github.com/Aveli-games/infestation/issues/11
-# TODO: how to texture programmatically? or can we texture a scene and instantiate that programatically?
 var line_nodes = []
 
 
@@ -27,8 +25,8 @@ func instantiate_network(dome_connections, self_ref):
 			pass
 		DomeConnections.connect_domes(dome_1, dome_2)
 	
-	var line_nodes = DomeConnections.draw_connections()
-	for i in line_nodes:
+	var new_line_nodes = DomeConnections.draw_connections()
+	for i in new_line_nodes:
 		self_ref.add_child(i)
 
 # dome_a, dome_b are references to dome nodes
@@ -51,8 +49,11 @@ func draw_connections():
 		var line = Line2D.new()
 		line.add_point(i.a.global_position)
 		line.add_point(i.b.global_position)
-		line.default_color = Color(1,1,1,0.2)
 		line.z_index=-1
+		# TODO: get proper texture
+		line.texture = load("res://art/squad_sprites/botanist_icon_placeholder.png")
+		line.texture_mode = Line2D.LINE_TEXTURE_TILE
+		line.texture_repeat = Line2D.TEXTURE_REPEAT_ENABLED
 		line_nodes.append(line)
 	return line_nodes
 

--- a/main.tscn
+++ b/main.tscn
@@ -10,6 +10,7 @@
 script = ExtResource("1_6j1u5")
 
 [node name="ColorRect" type="ColorRect" parent="."]
+z_index = -2
 offset_right = 1280.0
 offset_bottom = 720.0
 mouse_filter = 2


### PR DESCRIPTION
closes #11 

- dome connectors tucked behind everything (z-index = -1)
- background set behind that (z-index = -2)
- tiled texture applied programmatically

![Screenshot 2024-01-19 at 10 26 15 AM](https://github.com/Aveli-games/infestation/assets/16199008/892785f9-b261-4ca1-8901-7eb821cd1472)
