### PR TITLE
Win/lose conditions with placeholder display of win/loss

### DIFF
--- a/autoloads/Globals.gd
+++ b/autoloads/Globals.gd
@@ -1,6 +1,7 @@
 extends Node
 
 signal resource_updated
+signal research_win
 
 enum InfestationType {NONE, AIR, WATER, GROUND}
 enum InfestationStage {NONE, UNINFESTED, MINOR, MODERATE, MAJOR, FULL, LOST}
@@ -12,6 +13,8 @@ var BASE_DOME_INFESTATION_RATE = .1
 var BASE_CONNECTOR_INFESTATION_RATE = 0.1
 var BASE_INFESTATION_CHANCE = 0.012
 
+const RESEARCH_WIN_THRESHOLD = 500
+
 var resources = {
 	ResourceType.FOOD: 0,
 	ResourceType.FUEL: 0,
@@ -22,3 +25,5 @@ var resources = {
 func add_resource(type: ResourceType, change: int):
 	resources[type] += change
 	resource_updated.emit(type)
+	if type == ResourceType.RESEARCH && resources[type] >= RESEARCH_WIN_THRESHOLD:
+		research_win.emit()

--- a/dome.gd
+++ b/dome.gd
@@ -6,6 +6,7 @@ signal fully_infested
 signal infestation_removed
 signal targeted
 signal production_changed
+signal lost
 
 const DOME_SPRITES_PATH = "res://art/dome_sprites"
 const INFESTATION_COUNTDOWN = 30
@@ -45,6 +46,7 @@ func _on_infestation_check_timer_timeout():
 		if infestation_stage != Globals.InfestationStage.UNINFESTED:
 			infestation_stage = Globals.InfestationStage.UNINFESTED
 			$DomeStatus.text = "Safe"
+			infestation_removed.emit()
 			$ResourceGenerationTimer.start(1)
 			if not producing:
 				producing = true
@@ -87,7 +89,6 @@ func add_infestation(infestation_value: float):
 		
 		# when the dome is cleansed
 		if old_infestation_percentage > 0 && infestation_value < 0 && infestation_percentage == 0:
-			infestation_removed.emit()
 			##TODO: use signal in DomeConnections instead?
 			DomeConnections.dome_stop_spread(self)
 
@@ -162,6 +163,7 @@ func _on_dome_lost_countdown_timer_timeout():
 	infestation_stage = Globals.InfestationStage.LOST
 	$DomeStatus.text = "Lost"
 	$Building/BuildingSprite.modulate = Color.DIM_GRAY
+	lost.emit(self)
 	$Building/FlowerSprite.show()
 
 func _on_resource_generation_timer_timeout():

--- a/main.gd
+++ b/main.gd
@@ -1,7 +1,13 @@
 extends Node
 
+signal game_over
+signal victory
+
 var selected_squad: Squad
 var selected_action: Globals.ActionType = Globals.ActionType.NONE
+const DOME_REMAINING_LOSS_THRESHOLD = 5
+var remaining_domes = 15
+var cleanse_win_condition_unlocked = false
 
 var dome_type_limits = {
 	Globals.ResourceType.NONE: 0,
@@ -12,13 +18,15 @@ var dome_type_limits = {
 }
 
 func _ready():
+	Globals.research_win.connect(_on_victory)
+	
 	$Squads/Scientists.set_type(Globals.SquadType.SCIENTIST)
 	$Squads/Pyros.set_type(Globals.SquadType.PYRO)
 	$Squads/Botanists.set_type(Globals.SquadType.BOTANIST)
 	$Squads/Engineers.set_type(Globals.SquadType.ENGINEER)
 	
 	for child in $Squads.get_children():
-		child.move($Domes/Dome)
+		child.command(Globals.ActionType.FIGHT, $Domes/Dome)
 		child.selected.connect(_on_squad_selected)
 		if child.squad_type == Globals.SquadType.SCIENTIST:
 			child.research_toggled.connect(_on_research_toggled)
@@ -31,6 +39,8 @@ func _ready():
 	for child in $Domes.get_children():
 		child.targeted.connect(_on_dome_targeted)
 		child.production_changed.connect(_on_dome_production_changed)
+		child.lost.connect(_on_dome_lost)
+		child.infestation_removed.connect(_on_dome_cleansed)
 		if child == $Domes/Dome:
 			child.set_resource_type(Globals.ResourceType.FOOD)
 			child.set_sprite("res://art/dome_sprites/Dome_hq_96.png")
@@ -104,3 +114,27 @@ func _on_dome_production_changed(dome: Dome, is_producing: bool):
 		$UI.add_resource_producer(dome.resource_type, 1)
 	else:
 		$UI.add_resource_producer(dome.resource_type, -1)
+		
+func _on_dome_lost(dome: Dome):
+	remaining_domes -= 1
+	
+	# If HQ lost, game over. If we hit the dome loss threshold, game over
+	if dome == $Domes/Dome || remaining_domes <= DOME_REMAINING_LOSS_THRESHOLD:
+		game_over.emit()
+
+func _on_dome_cleanse_win_timer_timeout():
+	cleanse_win_condition_unlocked = true
+
+func _on_dome_cleansed():
+	# Check for cleanse win condition after 3 minutes
+	if cleanse_win_condition_unlocked:
+		for dome in $Domes.get_children():
+			if dome.infestation_stage > Globals.InfestationStage.UNINFESTED:
+				return
+		victory.emit()
+
+func _on_victory():
+	$WinLoseLabel.text = "You win!"
+
+func _on_game_over():
+	$WinLoseLabel.text = "You lose :("

--- a/main.tscn
+++ b/main.tscn
@@ -16,6 +16,11 @@ offset_right = 40.0
 offset_bottom = 40.0
 texture = ExtResource("2_mx7vp")
 
+[node name="DomeCleanseWinTimer" type="Timer" parent="."]
+wait_time = 10.0
+one_shot = true
+autostart = true
+
 [node name="Domes" type="Node2D" parent="."]
 position = Vector2(-16, 112)
 script = ExtResource("2_b5cb1")
@@ -82,4 +87,14 @@ position = Vector2(160, 120)
 
 [node name="UI" parent="." instance=ExtResource("4_6vko8")]
 
+[node name="WinLoseLabel" type="Label" parent="."]
+offset_left = 456.0
+offset_top = 16.0
+offset_right = 714.0
+offset_bottom = 104.0
+theme_override_font_sizes/font_size = 64
+
+[connection signal="game_over" from="." to="." method="_on_game_over"]
+[connection signal="victory" from="." to="." method="_on_victory"]
 [connection signal="gui_input" from="TextureRect" to="." method="_on_texture_rect_gui_input"]
+[connection signal="timeout" from="DomeCleanseWinTimer" to="." method="_on_dome_cleanse_win_timer_timeout"]


### PR DESCRIPTION
After 3 minutes if you cleanse all domes, win!

If you generate 500 research, win!

If HQ is lost, lose!

If 10 domes lost, lose!

Moved infestation_removed signal to when dome is set to uninfested since it is used to detect when dome is cleansed

closes #26 